### PR TITLE
fix: use XML hash for streaming shared strings

### DIFF
--- a/lib/utils/shared-strings.js
+++ b/lib/utils/shared-strings.js
@@ -1,3 +1,5 @@
+const SharedStringXform = require('../xlsx/xform/strings/shared-string-xform');
+
 class SharedStrings {
   constructor() {
     this._values = [];
@@ -21,10 +23,15 @@ class SharedStrings {
     return this._values[index];
   }
 
+  get sharedStringXform() {
+    return this._sharedStringXform || (this._sharedStringXform = new SharedStringXform());
+  }
+
   add(value) {
-    let index = this._hash[value];
+    const hashKey = value && value.richText ? this.sharedStringXform.toXml(value) : value;
+    let index = this._hash[hashKey];
     if (index === undefined) {
-      index = this._hash[value] = this._values.length;
+      index = this._hash[hashKey] = this._values.length;
       this._values.push(value);
     }
     this._totalRefs++;


### PR DESCRIPTION
## Summary
- when streaming from a WorkbookWriter, having `useSharedStrings` enabled was causing strings to be incorrectly repeated, likely due to `[object Object]` counting as one string in the cache. This patch uses the XML representation of these strings for the purpose of cacheing to avoid this issue

## Test plan
Before:
<img width="2630" height="1770" alt="CleanShot 2026-04-30 at 11 31 42@2x" src="https://github.com/user-attachments/assets/046383e7-d6eb-4400-be49-960ff53b64d9" />

After:
<img width="1814" height="1702" alt="CleanShot 2026-04-30 at 11 31 49@2x" src="https://github.com/user-attachments/assets/ff61d157-7e25-4722-bc53-21a61f07872b" />

## Related to source code (for typings update)

<!-- List with permalink into source code to prove that changes are true -->
