### PR TITLE
chore(deps): bump uuid 8.3.0 → 14.0.0 to clear audit notice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "saxes": "^5.0.1",
         "tmp": "^0.2.0",
         "unzipper": "^0.10.11",
-        "uuid": "^8.3.0"
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "@babel/cli": "^7.10.5",
@@ -12911,22 +12911,6 @@
         }
       }
     },
-    "node_modules/puppeteer/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/puppeteer/node_modules/yargs": {
       "version": "17.7.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
@@ -15785,10 +15769,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8flags": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "saxes": "^5.0.1",
     "tmp": "^0.2.0",
     "unzipper": "^0.10.11",
-    "uuid": "^8.3.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",


### PR DESCRIPTION
## Summary

Bumps `uuid` from `^8.3.0` to `^14.0.0` to clear the `GHSA-w5hq-g745-h8pq` audit advisory that downstream consumers see on `npm install`.

The advisory affects all uuid versions `<14.0.0`, so 9.x / 10.x / 11.x / 12.x / 13.x would just trade one notice for another — only `^14` closes it cleanly.

## Compatibility

uuid 14 retains CommonJS support. The only call pattern in this repo:

```js
const {v4: uuidv4} = require('uuid');
```

(in `lib/xlsx/xform/sheet/cf-ext/cf-rule-ext-xform.js` and `lib/xlsx/xform/pivot-table/pivot-table-xform.js`) is unchanged. No API-shape changes.

## Test plan

- [x] `npm run test:unit` → 884 passing
- [x] `npm run test:integration` → 200 passing
- [x] `npm audit` after bump → no remaining notice on the `uuid` line