### PR TITLE
Fix: pin uuid to ^9.0.1 to keep browserify build working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "saxes": "^5.0.1",
         "tmp": "^0.2.0",
         "unzipper": "^0.10.11",
-        "uuid": "^8.3.0"
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "@babel/cli": "^7.10.5",
@@ -12911,22 +12911,6 @@
         }
       }
     },
-    "node_modules/puppeteer/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/puppeteer/node_modules/yargs": {
       "version": "17.7.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
@@ -15785,7 +15769,14 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "saxes": "^5.0.1",
     "tmp": "^0.2.0",
     "unzipper": "^0.10.11",
-    "uuid": "^8.3.0"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",


### PR DESCRIPTION
## Summary

`npm install` had drifted to `uuid@14.0.0` locally, which broke `npm run build` because uuid@14 dropped the `main` field in favor of `exports`-only — and browserify@16 doesn't honor `exports`. Investigation surfaced a deeper issue:

- **uuid@8** (previous pin): npm now flags it as deprecated.
- **uuid@14** (current latest): no `main` field → browserify can't resolve it.
- **uuid@11** (npm's recommended CJS target): ships ES2021 syntax (`??=`) in its CJS bundle that browserify@16's parser can't read.
- **uuid@9.0.1**: highest version that still has a `main` field AND no ES2021 syntax in CJS output. Builds clean.

This PR bumps the pin from `^8.3.0` to `^9.0.1`. A future PR upgrading browserify (or replacing it) would unlock uuid@11.

## Files changed

- `package.json` — uuid `^8.3.0` → `^9.0.1`
- `package-lock.json` — uuid resolved to 9.0.1; incidental cleanup of an orphaned `puppeteer/node_modules/typescript` entry that npm pruned

## Test plan

\`\`\`bash
npm install --legacy-peer-deps
npm run build       # passes (was failing before)
npm run test:unit   # 884 passing, 1 pending, 0 failing
node -e "const {v4} = require('uuid'); console.log(v4())"  # API smoke test
\`\`\`

The \`--legacy-peer-deps\` requirement is pre-existing (eslint-config-airbnb-base@14 vs eslint@8 conflict) and out of scope for this PR.

## Related to source code

- https://github.com/protobi/exceljs/blob/master/lib/xlsx/xform/pivot-table/pivot-table-xform.js#L1
- https://github.com/protobi/exceljs/blob/master/lib/xlsx/xform/sheet/cf-ext/cf-rule-ext-xform.js#L1