### PR TITLE
Cherry-pick #50 + add regression tests for richText shared-string dedup

### DIFF
--- a/lib/utils/shared-strings.js
+++ b/lib/utils/shared-strings.js
@@ -1,3 +1,5 @@
+const SharedStringXform = require('../xlsx/xform/strings/shared-string-xform');
+
 class SharedStrings {
   constructor() {
     this._values = [];
@@ -21,10 +23,15 @@ class SharedStrings {
     return this._values[index];
   }
 
+  get sharedStringXform() {
+    return this._sharedStringXform || (this._sharedStringXform = new SharedStringXform());
+  }
+
   add(value) {
-    let index = this._hash[value];
+    const hashKey = value && value.richText ? this.sharedStringXform.toXml(value) : value;
+    let index = this._hash[hashKey];
     if (index === undefined) {
-      index = this._hash[value] = this._values.length;
+      index = this._hash[hashKey] = this._values.length;
       this._values.push(value);
     }
     this._totalRefs++;

--- a/spec/unit/utils/shared-strings.spec.js
+++ b/spec/unit/utils/shared-strings.spec.js
@@ -25,4 +25,36 @@ describe('SharedStrings', () => {
     expect(ss.getString(iXml)).to.equal('<tag>value</tag>');
     expect(ss.getString(iAmpersand)).to.equal('&');
   });
+
+  it('Deduplicates richText values by their XML representation', () => {
+    // regression: previously, richText objects all collapsed to the
+    // hash key "[object Object]", deduping every richText cell into one entry
+    const ss = new SharedStrings();
+
+    const a = {richText: [{text: 'Hello'}]};
+    const b = {richText: [{text: 'Hello'}]};
+    const c = {richText: [{text: 'Goodbye'}]};
+
+    const iA = ss.add(a);
+    const iB = ss.add(b);
+    const iC = ss.add(c);
+
+    expect(iA).to.equal(iB);
+    expect(iC).to.not.equal(iA);
+    expect(ss.count).to.equal(2);
+    expect(ss.totalRefs).to.equal(3);
+  });
+
+  it('Distinguishes richText entries that differ only in formatting', () => {
+    const ss = new SharedStrings();
+
+    const plain = {richText: [{text: 'Hello'}]};
+    const bold = {richText: [{font: {bold: true}, text: 'Hello'}]};
+
+    const iPlain = ss.add(plain);
+    const iBold = ss.add(bold);
+
+    expect(iPlain).to.not.equal(iBold);
+    expect(ss.count).to.equal(2);
+  });
 });


### PR DESCRIPTION
## Summary

Cherry-picks [protobi/exceljs#50](https://github.com/protobi/exceljs/pull/50) by @gwkline and adds the regression tests it was missing.

**The bug:** `SharedStrings.add()` used `value` directly as a hash key. For richText values (objects with a `richText` array), JavaScript coerces the object to the string `"[object Object]"`, so every richText cell deduped into a single shared-string entry — corrupting the workbook's strings table.

**The fix (cherry-picked):** When the value is a richText object, hash by its rendered XML representation instead. Plain strings are unchanged.

**This PR also adds** unit tests covering:
1. Two equal richText values share one entry; a different one gets its own
2. richText values that differ only in formatting (e.g. plain vs bold) are NOT deduped

Without these tests, the bug could silently regress.

## Upstream context

This bug was first reported as [exceljs/exceljs#2267](https://github.com/exceljs/exceljs/issues/2267) (May 2023, @techiesalman). An alternative fix was opened upstream as [exceljs/exceljs#2588](https://github.com/exceljs/exceljs/pull/2588) (Nov 2023, @PetrChalov) but has been stale since Feb 2024. @gwkline rediscovered the bug independently and submitted a different fix to the protobi fork. The regression tests added in this PR cover both fix approaches.

## Files changed

- `lib/utils/shared-strings.js` — cherry-picked from protobi#50 (commit `5f89673`): import `SharedStringXform` lazily, hash richText by rendered XML
- `spec/unit/utils/shared-strings.spec.js` — two new test cases

## Test plan

```bash
npm run test:unit
# 4 passing in SharedStrings (was 2 before this PR)
```

Confirmed the new tests fail without the cherry-picked fix:

```
✗ Deduplicates richText values by their XML representation
  AssertionError: expected +0 to not equal +0
✗ Distinguishes richText entries that differ only in formatting
  AssertionError: expected +0 to not equal +0
```

These failures are exactly the regression: every richText collapses to index 0.

## Related to source code

- https://github.com/protobi/exceljs/blob/master/lib/utils/shared-strings.js
- protobi PR: https://github.com/protobi/exceljs/pull/50
- Upstream issue: https://github.com/exceljs/exceljs/issues/2267
- Upstream PR (stale alt fix): https://github.com/exceljs/exceljs/pull/2588
