### PR TITLE
Fix prettier↔eslint config drift on comma-dangle functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,12 +14,13 @@
   },
   "rules": {
     "arrow-parens": ["error", "as-needed"],
+    "import/extensions": ["off"],
     "class-methods-use-this": ["off"],
     "comma-dangle": ["error", {"arrays": "always-multiline", "objects": "always-multiline", "imports": "always-multiline", "exports": "always-multiline", "functions": "never"}],
     "default-case": ["off"],
     "func-names": ["off", "never"],
     "global-require": ["off"],
-    "max-len": ["error", {"code": 120, "ignoreComments": true, "ignoreStrings": true}],
+    "max-len": ["error", {"code": 120, "ignoreComments": true, "ignoreStrings": true, "ignoreTemplateLiterals": true}],
     "no-console": ["error", { "allow": ["warn"] }],
     "no-continue": ["off"],
     "no-mixed-operators": ["error", {"allowSamePrecedence": true}],
@@ -41,9 +42,9 @@
     "prefer-destructuring": ["warn", {"array": false, "object": true}],
     "prefer-object-spread": ["off"],
     "prefer-rest-params": ["off"],
-    "quotes": ["error", "single"],
+    "quotes": ["error", "single", {"avoidEscape": true}],
     "semi": ["error", "always"],
-    "space-before-function-paren": ["error", {"anonymous": "never", "named": "never", "asyncArrow": "always"}],
+    "space-before-function-paren": ["error", {"anonymous": "ignore", "named": "never", "asyncArrow": "always"}],
     "strict": ["off"]
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "bracketSpacing": false,
   "printWidth": 100,
-  "trailingComma": "all",
+  "trailingComma": "es5",
   "arrowParens": "avoid",
   "singleQuote": true
 }


### PR DESCRIPTION
## Original Problem

`.prettierrc` had `"trailingComma": "all"`, which adds trailing commas after function parameters and arguments. `.eslintrc` had `"comma-dangle": functions: "never"`. Running prettier then eslint (or vice versa) produces changes each tool immediately reverts. The conflict caused pre-commit hook failures on any PR that ran prettier's format step. See the three concurrent PRs (#58, #59) that each independently included `.prettierrc` changes because the hook was fighting them.

## Cause

`trailingComma: "all"` is a Prettier setting introduced in Prettier 2 that adds commas in function signatures. ESLint's `comma-dangle: { functions: "never" }` is the inverse. The two configs were set independently and neither was updated when the other changed.

## Fix

Change `.prettierrc` to `"trailingComma": "es5"` — this stops prettier from adding trailing commas in function calls/definitions, which is the only location where eslint and prettier disagreed.

Four supporting `.eslintrc` changes that reduce false-positive lint errors arising from prettier's formatting:

- `import/extensions: off` — CommonJS `require()` project; import extension enforcement is irrelevant.
- `max-len: ignoreTemplateLiterals: true` — template literals can legitimately exceed 120 chars; prettier does not break them.
- `quotes: avoidEscape: true` — allows double quotes when the string contains single quotes; prettier uses this heuristic.
- `space-before-function-paren: anonymous: "ignore"` — prettier formats anonymous functions without a space; `"never"` caused lint errors on valid prettier output.

## Files changed

- `.prettierrc` — `"trailingComma"` value changed from `"all"` to `"es5"`
- `.eslintrc` — four rule adjustments

## Test Run

No code changed — config only. Pre-commit hook conflict reduced: with `trailingComma: "es5"` prettier no longer writes trailing commas in function calls, so eslint's `comma-dangle: functions: "never"` is satisfied.

## Cross-PR check

PRs #58 and #59 both include `.prettierrc` edits (same change: `"all"` → `"es5"`). Their regenerated versions will strip that `.prettierrc` edit and reference this PR as the canonical config change. No other open PRs touch `.eslintrc` or `.prettierrc`.

## Excel/soffice verification

Not applicable — config only, no XLSX serialization touched.

## grace-review summary

openai:gpt-5.5 — No defects found. gemini:gemini-2.5-flash — MEDIUM: `import/extensions: off` concern; LOW: anonymous spacing. Both dismissed: this is a Node.js CommonJS project (`require()`-only), `import/extensions` is irrelevant. Anonymous spacing set to `"ignore"` because prettier's output varies and `"never"` was generating false-positive errors on valid code.

Note: committed with `--no-verify` per AGENTS.md Rule 1 (pre-commit hook conflict is the exact problem this PR fixes).