### PR TITLE
chore(deps): bump fast-csv 4 → 5 to clear deprecation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "archiver": "^7.0.1",
         "dayjs": "^1.8.34",
-        "fast-csv": "^4.3.1",
+        "fast-csv": "^5.0.0",
         "jszip": "^3.10.1",
         "readable-stream": "^3.6.0",
         "saxes": "^5.0.1",
@@ -1728,27 +1728,22 @@
       }
     },
     "node_modules/@fast-csv/format": {
-      "version": "4.3.5",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@fast-csv/format/-/format-5.0.7.tgz",
+      "integrity": "sha512-VdypoRxv7PF+LsyPouTMKdB0d76hync+gLpgdNqfqVK44MsgW4oiCJSdrki2FisWT7v2QGUYDHjp4L7w5oO6gw==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^14.0.1",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isequal": "^4.5.0",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.isnil": "^4.0.0"
+        "lodash.escaperegexp": "^4.1.2"
       }
     },
     "node_modules/@fast-csv/parse": {
-      "version": "4.3.6",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@fast-csv/parse/-/parse-5.0.7.tgz",
+      "integrity": "sha512-MeuDeQj0DVmIGWky8STaKtvj232Gpq8kjrOGplHJ99Os7OO5CetVfXvUGqX/3GHYFOUsz6FK8isWtDY2XTFNWw==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^14.0.1",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.groupby": "^4.6.0",
-        "lodash.isfunction": "^3.0.9",
-        "lodash.isnil": "^4.0.0",
-        "lodash.isundefined": "^3.0.1",
         "lodash.uniq": "^4.5.0"
       }
     },
@@ -2591,6 +2586,7 @@
     },
     "node_modules/@types/node": {
       "version": "14.18.45",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/parse-json": {
@@ -6693,11 +6689,13 @@
       }
     },
     "node_modules/fast-csv": {
-      "version": "4.3.6",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-5.0.7.tgz",
+      "integrity": "sha512-KirK9wYIUXF/xTYmg/jv9ehUWbQ4Faf6XutuJKlEz72eoqKMMLdCnz+rGDeBSjpV2wwkHQnLSuJ5i+FRRnzZwA==",
       "license": "MIT",
       "dependencies": {
-        "@fast-csv/format": "4.3.5",
-        "@fast-csv/parse": "4.3.6"
+        "@fast-csv/format": "5.0.7",
+        "@fast-csv/parse": "5.0.7"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -9817,30 +9815,14 @@
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
       "license": "MIT"
     },
     "node_modules/lodash.groupby": {
       "version": "4.6.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isfunction": {
-      "version": "3.0.9",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isnil": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isundefined": {
-      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -9855,6 +9837,8 @@
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "dependencies": {
     "archiver": "^7.0.1",
     "dayjs": "^1.8.34",
-    "fast-csv": "^4.3.1",
+    "fast-csv": "^5.0.0",
     "jszip": "^3.10.1",
     "readable-stream": "^3.6.0",
     "saxes": "^5.0.1",


### PR DESCRIPTION
## Original Problem

`fast-csv` v4.x shows a deprecation notice on `npm install` for downstream consumers. Bumping to v5 clears the notice and brings in maintenance updates.

## Cause

`fast-csv@4.3.1` was pinned; v5.0.0 was released in 2023 and the v4 line is no longer maintained.

## Fix

Bumped `fast-csv` from `^4.3.1` to `^5.0.0` in `package.json`. Ran `npm install --legacy-peer-deps` to update `package-lock.json` (legacy-peer-deps required for the existing devDependency ESLint config tree).

The only `fast-csv` usage in this repo is `lib/csv/csv.js`, which calls:
- `fastCsv.parse(options.parserOptions)` — stream pipeline; API unchanged in v5.
- `fastCsv.format(options.formatterOptions)` — stream pipeline; API unchanged in v5.

## Files changed

- `package.json` — `fast-csv` version string
- `package-lock.json` — updated `@fast-csv/format`, `@fast-csv/parse` entries (v4.3.5 → v5.0.7)

## Test Run

Runtime smoke test (AGENTS.md Rule 7): wrote a 2-row workbook to CSV via `wb.csv.writeFile()`, read it back via `wb2.csv.readFile()`, verified row values match. Passed.

```
Rows read back: [[1,"hello",true],[2,"world",false]]
fast-csv smoke test: PASS
```

CSV integration test `spec/integration/issues/issue-991-csv-read-dates.spec.js`: 1 passing.

## Cross-PR check

No other open senoff PR touches `package.json` or `package-lock.json`. Unzipper bump is in a separate PR per AGENTS.md Rule 8.

## Excel/soffice verification

Not applicable — dep bump only, no XLSX serialization path touched.

## grace-review summary

openai:gpt-5.5 — No defects found. gemini — CRITICAL: "major version bump without code adaptation." Dismissed: smoke test and CSV integration test both pass; `fast-csv.parse()` and `fast-csv.format()` stream APIs are unchanged in v5. gemini's concern was generic, not informed by the actual API surface used in this codebase.

Note: committed with `--no-verify` per AGENTS.md Rule 1.